### PR TITLE
Added MediaLive Multiplex Alert Support

### DIFF
--- a/api/events/lambda_function.py
+++ b/api/events/lambda_function.py
@@ -39,7 +39,7 @@ def lambda_handler(event, _):
             item["type"] = item["type"] + ": " + event["detail"]["eventName"]
 
         # catch all the various forms of ARN from the media services
-        arn_expr = parse('$..arn|aRN|resource-arn|channel_arn|flowArn|PlaybackConfigurationArn|resourceArn')
+        arn_expr = parse('$..arn|aRN|resource-arn|channel_arn|multiplex_arn|flowArn|PlaybackConfigurationArn|resourceArn')
         original_arns = [match.value for match in arn_expr.find(event)]
         arns = []
         # remove arn that is for userIdentity or inputSecurityGroup
@@ -58,7 +58,6 @@ def lambda_handler(event, _):
                 # multiplex pipeline alerts do not have a "detail.channel_arn" property.
                 if "Multiplex" in event["detail-type"]:
                     event["resource_arn"] = event["detail"]["multiplex_arn"]
-                    item["resource_arn"] = event["detail"]["multiplex_arn"]
                 else:
                     event["resource_arn"] = event["detail"]["channel_arn"]
                 event["alarm_id"] = event["detail"]["alarm_id"]

--- a/html/js/app/mappers/nodes/medialive.js
+++ b/html/js/app/mappers/nodes/medialive.js
@@ -9,7 +9,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             var url = current[0];
             var api_key = current[1];
             return new Promise(function(resolve, reject) {
-                server.get(url + "/cached/medialive-channel/" + regionName, api_key).then(function(channels) {
+                server.get(`${url}/cached/medialive-channel/${regionName}`, api_key).then(function(channels) {
                     for (let cache_entry of channels) {
                         map_channel(cache_entry);
                     }
@@ -26,7 +26,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             var url = current[0];
             var api_key = current[1];
             return new Promise((resolve, reject) => {
-                server.get(url + "/cached/medialive-input/" + regionName, api_key).then((inputs) => {
+                server.get(`${url}/cached/medialive-input/${regionName}`, api_key).then((inputs) => {
                     for (let cache_entry of inputs) {
                         map_input(cache_entry);
                     }
@@ -43,7 +43,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             var url = current[0];
             var api_key = current[1];
             return new Promise((resolve, reject) => {
-                server.get(url + "/cached/medialive-multiplex/" + regionName, api_key).then((inputs) => {
+                server.get(`${url}/cached/medialive-multiplex/${regionName}`, api_key).then((inputs) => {
                     for (let cache_entry of inputs) {
                         map_multiplex(cache_entry);
                     }
@@ -63,20 +63,20 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             var rgb = "#1E8900";
             var node_type = "MediaLive Channel";
             var node_data = {
-                "cache_update": cache_entry.updated,
-                "id": id,
-                "region": cache_entry.region,
-                "shape": "image",
-                "image": {
-                    "unselected": null,
-                    "selected": null
+                cache_update: cache_entry.updated,
+                id: id,
+                region: cache_entry.region,
+                shape: "image",
+                image: {
+                    unselected: null,
+                    selected: null
                 },
-                "header": "<b>" + node_type + ":</b> " + name,
-                "data": channel,
-                "title": node_type,
-                "name": name,
-                "size": 55,
-                "render": {
+                header: `<b>${node_type}:</b> ${name}`,
+                data: channel,
+                title: node_type,
+                name: name,
+                size: 55,
+                render: {
                     normal_unselected: (function() {
                         var local_node_type = node_type;
                         var local_name = name;
@@ -112,7 +112,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         };
                     })()
                 },
-                "console_link": (function() {
+                console_link: (function() {
                     var id = channel.Id;
                     var region = channel.Arn.split(":")[3];
                     return function() {
@@ -120,7 +120,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         return html;
                     };
                 })(),
-                "cloudwatch_link": (function() {
+                cloudwatch_link: (function() {
                     var id = channel.Id;
                     var region = channel.Arn.split(":")[3];
                     return function() {
@@ -142,20 +142,20 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             var node_type = "MediaLive Input";
             var rgb = "#6AAF35";
             var node_data = {
-                "cache_update": cache_entry.updated,
-                "id": input.Arn,
-                "region": cache_entry.region,
-                "shape": "image",
-                "image": {
-                    "unselected": null,
-                    "selected": null
+                cache_update: cache_entry.updated,
+                id: input.Arn,
+                region: cache_entry.region,
+                shape: "image",
+                image: {
+                    unselected: null,
+                    selected: null
                 },
-                "header": "<b>" + node_type + ":</b> " + name,
-                "data": input,
-                "title": node_type,
-                "name": name,
-                "size": 55,
-                "render": {
+                header: `<b>${node_type}:</b> ${name}`,
+                data: input,
+                title: node_type,
+                name: name,
+                size: 55,
+                render: {
                     normal_unselected: (function() {
                         var local_node_type = node_type;
                         var local_name = name;
@@ -191,7 +191,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         };
                     })()
                 },
-                "console_link": (function() {
+                console_link: (function() {
                     var id = input.Id;
                     var region = input.Arn.split(":")[3];
                     return function() {
@@ -199,7 +199,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         return html;
                     };
                 })(),
-                "cloudwatch_link": (function() {
+                cloudwatch_link: (function() {
                     return function() {
                         var html = `https://console.aws.amazon.com/cloudwatch/home`;
                         return html;
@@ -220,20 +220,20 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             // var rgb = "#456e26";
             var rgb = "#6a8258";
             var node_data = {
-                "cache_update": cache_entry.updated,
-                "id": input.Arn,
-                "region": cache_entry.region,
-                "shape": "image",
-                "image": {
-                    "unselected": null,
-                    "selected": null
+                cache_update: cache_entry.updated,
+                id: input.Arn,
+                region: cache_entry.region,
+                shape: "image",
+                image: {
+                    unselected: null,
+                    selected: null
                 },
-                "header": "<b>" + node_type + ":</b> " + name,
-                "data": input,
-                "title": node_type,
-                "name": name,
-                "size": 55,
-                "render": {
+                header: `<b>${node_type}:</b> ${name}`,
+                data: input,
+                title: node_type,
+                name: name,
+                size: 55,
+                render: {
                     normal_unselected: (function() {
                         var local_node_type = node_type;
                         var local_name = name;
@@ -269,7 +269,7 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         };
                     })()
                 },
-                "console_link": (function() {
+                console_link: (function() {
                     var id = input.Id;
                     var region = input.Arn.split(":")[3];
                     return function() {
@@ -277,10 +277,9 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         return html;
                     };
                 })(),
-                "cloudwatch_link": (function() {
+                cloudwatch_link: (function() {
                     return function() {
-                        var html = `https://console.aws.amazon.com/cloudwatch/home`;
-                        return html;
+                        return 'https://console.aws.amazon.com/cloudwatch/home';
                     };
                 })()
             };
@@ -298,11 +297,9 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                         promises.push(update_inputs(region_name));
                         promises.push(update_multiplexes(region_name));
                     }
-                    Promise.all(promises).then(function() {
-                        resolve();
-                    }).catch(function() {
-                        reject();
-                    });
+                    Promise.all(promises)
+                        .then(resolve)
+                        .catch(reject);
                 }).catch(function(error) {
                     console.log(error);
                     reject(error);
@@ -310,8 +307,5 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
             });
         };
 
-        return {
-            "name": "MediaLive Inputs, Channels, Multiplexes",
-            "update": update
-        };
+        return { name: "MediaLive Inputs, Channels, Multiplexes", update: update };
     });

--- a/html/js/app/plugins.js
+++ b/html/js/app/plugins.js
@@ -44,6 +44,7 @@ define({
     "overlays": [
         "app/ui/overlays/mediaconnect_flow",
         "app/ui/overlays/medialive_channel",
+        "app/ui/overlays/medialive_multiplex",
     ],
     "default-overlay": "app/ui/overlays/alarms_only"
 });

--- a/html/js/app/ui/overlays/medialive_multiplex.js
+++ b/html/js/app/ui/overlays/medialive_multiplex.js
@@ -1,0 +1,40 @@
+/*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+       SPDX-License-Identifier: Apache-2.0 */
+
+       define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay_tools", "app/model"],
+       function($, _, alert_events, alarms, tools, model) {
+
+           var match_type = "MediaLive Multiplex";
+
+           var decorate_alarms = function(drawing, font_size, width, height, id) {
+               var alarm_count = 0;
+               for (let item of alarms.get_subscribers_with_alarms().current) {
+                   if (item.ResourceArn == id) {
+                       alarm_count += item.AlarmCount;
+                   }
+               }
+               tools.set_alarm_text("Active alarms: " + alarm_count, drawing, font_size, width);
+           };
+
+           var decorate_events = function(drawing, font_size, width, height, id) {
+               var pipeline_alerts = [0, 0];
+               for (let item of alert_events.get_cached_events().current) {
+                   if (item.resource_arn == id) {
+                       pipeline_alerts[parseInt(item.detail.pipeline)] += 1;
+                   }
+               }
+               tools.set_event_text("Pipeline alerts: " + JSON.stringify(pipeline_alerts), drawing, font_size, width);
+           };
+
+           var decorate = function(drawing, font_size, width, height, id) {
+               decorate_alarms(drawing, font_size, width, height, id);
+               decorate_events(drawing, font_size, width, height, id);
+           };
+
+           return {
+               "match_type": match_type,
+               "decorate": decorate,
+               "informational": true
+           };
+
+       });


### PR DESCRIPTION
*Issue #82:*

*Description of changes:*

### Handling Multiplex Alerts
All Multiplex alerts will have a source of `aws.medialive`. That means the incoming alert can be from a running MediaLive Channel or a MediaLive Multiplex. There are several ways to tell them apart, but this PR simply checks the alert's `detail-type` value. Every multiplex alert will have `Multiplex` in the `detail-type`. In addition, multiplex alerts do not have a `detail.channel_arn` attribute, instead they will contain `detail.multiplex_arn`.

### Adding alert content to multiplex nodes
Added a `medialive_multiplex` overlay to handle `MediaLive Multiplex` specific nodes. Here we handle the logic to aggregate pipeline alert count and active alarm count. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Screenshots*
![Screenshot MSAM 2020-02-18 11 25 14](https://user-images.githubusercontent.com/7432155/74764597-9c7fd380-5247-11ea-8c9b-c0626b49942d.png)
