### PR TITLE
MediaLive Visualization enhancement represent pipelines separately

### DIFF
--- a/api/events/lambda_function.py
+++ b/api/events/lambda_function.py
@@ -17,8 +17,8 @@ from botocore.exceptions import ClientError
 from jsonpath_ng import parse
 
 DYNAMO_RESOURCE = boto3.resource('dynamodb', region_name=os.environ["EVENTS_TABLE_REGION"])
-DYNAMO_TABLE = DYNAMO_RESOURCE.Table(os.environ["EVENTS_TABLE_NAME"])
-CLOUDWATCH_EVENTS_TABLE_NAME = DYNAMO_RESOURCE.Table(os.environ["CLOUDWATCH_EVENTS_TABLE_NAME"])
+EVENTS_TABLE = DYNAMO_RESOURCE.Table(os.environ["EVENTS_TABLE_NAME"])
+CLOUDWATCH_EVENTS_TABLE = DYNAMO_RESOURCE.Table(os.environ["CLOUDWATCH_EVENTS_TABLE_NAME"])
 
 
 def lambda_handler(event, _):
@@ -67,7 +67,7 @@ def lambda_handler(event, _):
                 event["expires"] = event["timestamp"] + \
                     int(os.environ["ITEM_TTL"])
                 event["detail"]["time"] = event["time"]
-                DYNAMO_TABLE.put_item(Item=event)
+                EVENTS_TABLE.put_item(Item=event)
                 if "Multiplex" in event["detail-type"]:
                     print("Multiplex alert stored")
                 else:
@@ -99,7 +99,7 @@ def lambda_handler(event, _):
         if "resource_arn" in item:
             print("Storing media service event.")
             print(item)
-            CLOUDWATCH_EVENTS_TABLE_NAME.put_item(Item=item)
+            CLOUDWATCH_EVENTS_TABLE.put_item(Item=item)
         else:
             print("Skipping this event. " + item["type"])
 

--- a/api/msam/chalicelib/connections.py
+++ b/api/msam/chalicelib/connections.py
@@ -204,6 +204,7 @@ def medialive_channel_multiplex_ddb_items():
     Identify and format MediaLive channel to EML Multiplex connections for cache storage.
     """
     items = []
+    ml_service_name = "medialive-channel-multiplex"
     try:
         # get medialive channels
         medialive_ch_cached = cache.cached_by_service("medialive-channel")
@@ -218,10 +219,12 @@ def medialive_channel_multiplex_ddb_items():
                     for ml_multiplex in medialive_mp_cached:
                         ml_multiplex_data = json.loads(ml_multiplex["data"])
                         if multiplex_id == ml_multiplex_data["Id"]:
-                            # create a 'connection' out of matches
-                            config = {"from": ml_channel_data["Arn"], "to": ml_multiplex_data["Arn"], "program": program_name}
-                            print(config)
-                            items.append(connection_to_ddb_item(ml_channel_data["Arn"], ml_multiplex_data["Arn"], "medialive-channel-multiplex", config))
+                            pipelines_count = ml_channel_data["PipelinesRunningCount"]
+                            for pl in range(pipelines_count):
+                                # create a 'connection' out of matches
+                                config = {"from": ml_channel_data["Arn"], "to": ml_multiplex_data["Arn"], "program": program_name, "pipeline": pl}
+                                print(config)
+                                items.append(connection_to_ddb_item_pl(ml_channel_data["Arn"], ml_multiplex_data["Arn"], ml_service_name, config))
     except ClientError as error:
         print(error)
     return items

--- a/html/js/app/mappers/connections/medialive_channel_mediapackage_channel.js
+++ b/html/js/app/mappers/connections/medialive_channel_mediapackage_channel.js
@@ -1,8 +1,8 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-define(["jquery", "app/model", "app/server", "app/connections"],
-    function($, model, server, connections) {
+define(["jquery", "lodash", "app/model", "app/server", "app/connections"],
+    function($, _, model, server, connections) {
 
         var update_connections = function() {
             var current = connections.get_current();
@@ -12,15 +12,25 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                 server.get(url + "/cached/medialive-channel-mediapackage-channel/global", api_key).then((connections) => {
                     for (let connection of connections) {
                         var data = JSON.parse(connection.data);
+                        var human_type = "HLS";
+                        var smoothType = 'discrete';
+                        if (_.has(data, "pipeline")) {
+                            human_type += ` ${data.pipeline}`;
+                            smoothType = data.pipeline === 1 ? 'curvedCCW' : 'curvedCW';
+                        }
                         model.edges.update({
-                            "id": connection.arn,
-                            "to": connection.to,
-                            "from": connection.from,
-                            "data": data,
-                            "label": "HLS",
-                            "arrows": "to",
-                            "color": {
-                                "color": "black"
+                            id: connection.arn,
+                            to: connection.to,
+                            from: connection.from,
+                            data: data,
+                            label: human_type,
+                            arrows: "to",
+                            color: {
+                                color: "black"
+                            },
+                            smooth: {
+                                enabled: true,
+                                type: smoothType
                             }
                         });
                     }

--- a/html/js/app/mappers/connections/medialive_input_channel.js
+++ b/html/js/app/mappers/connections/medialive_input_channel.js
@@ -1,8 +1,8 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-define(["jquery", "app/model", "app/server", "app/connections"],
-    function($, model, server, connections) {
+define(["jquery", "lodash", "app/model", "app/server", "app/connections"],
+    function($, _, model, server, connections) {
 
         var update_connections = function() {
             var current = connections.get_current();
@@ -13,15 +13,25 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                     for (let connection of connections) {
                         var data = JSON.parse(connection.data);
                         var human_type = data.type.replace(/\_/, " ");
+                        var smoothType = 'discrete';
+                        
+                        if (_.has(data, "pipeline")) {
+                            human_type += ` ${data.pipeline}`;
+                            smoothType = data.pipeline === 1 ? 'curvedCCW' : 'curvedCW';
+                        }
                         model.edges.update({
-                            "id": connection.arn,
-                            "to": connection.to,
-                            "from": connection.from,
-                            "data": data,
-                            "label": human_type,
-                            "arrows": "to",
-                            "color": {
-                                "color": "black"
+                            id: connection.arn,
+                            to: connection.to,
+                            from: connection.from,
+                            data: data,
+                            label: human_type,
+                            arrows: "to",
+                            color: {
+                                color: "black"
+                            },
+                            smooth: {
+                                enabled: true,
+                                type: smoothType
                             }
                         });
                     }

--- a/html/js/app/mappers/connections/mediapackage_channel_endpoint.js
+++ b/html/js/app/mappers/connections/mediapackage_channel_endpoint.js
@@ -13,14 +13,18 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                     for (let connection of connections) {
                         var data = JSON.parse(connection.data);
                         model.edges.update({
-                            "id": connection.arn,
-                            "to": connection.to,
-                            "from": connection.from,
-                            "data": data,
-                            "label": data.package,
-                            "arrows": "to",
-                            "color": {
-                                "color": "black"
+                            id: connection.arn,
+                            to: connection.to,
+                            from: connection.from,
+                            data: data,
+                            label: data.package,
+                            arrows: "to",
+                            color: {
+                                color: "black"
+                            },
+                            smooth: {
+                                enabled: true,
+                                type: 'discrete'
                             }
                         });
                     }


### PR DESCRIPTION
*Issue #80:*

*Description of changes:*

### Connection Mapping 
- The cloud now identifies one or more connections between _MediaLive inputs and channels_
- The cloud now identifies one or more connections between _MediaLive channels and MediaPackage channels_

### DynamoDB Connection IDs
- IDs generated for connections stored in the Content table now include the pipeline number

### UI Enhancements
- Connection labeling now includes the pipeline number
- Connection rendering is now smooth/curved

### Smooth Pipelines Example
![Screenshot Seperate Pipelines 2020-03-05 03 43 58](https://user-images.githubusercontent.com/7432155/75969995-59ec0700-5e95-11ea-8984-98f6c594fa66.png)

![Screenshot Seperate Pipelines 2 2020-03-05 04 38 08](https://user-images.githubusercontent.com/7432155/75973682-36c45600-5e9b-11ea-9153-d389193cb0df.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
