### PR TITLE
Fixed degraded state by enforcing checks against same pipelines

### DIFF
--- a/api/msam/chalicelib/cloudwatch.py
+++ b/api/msam/chalicelib/cloudwatch.py
@@ -153,17 +153,27 @@ def get_cloudwatch_events_state_groups(state):
     group["degraded"] = []
     events = get_cloudwatch_events_state(state)
     for event in events:
-        resource_arn = event["resource_arn"]
+        arn = event["resource_arn"]
+        pl = event["detail"]["pipeline"]
         def is_same_arn(i):
-            return bool(i["resource_arn"] == resource_arn)
+            return bool(i["resource_arn"] == arn)
+        def is_same_pl(i):
+            return bool("pipeline" in i["detail"] and i["detail"]["pipeline"] == pl)
+        def is_diff_pl(i):
+            return bool("pipeline" in i["detail"] and i["detail"]["pipeline"] != pl)
         def is_pl_down(i):
             return bool("pipeline_state" in i["detail"] and not i["detail"]["pipeline_state"])
-        same_events = list(filter(is_same_arn, events))
-        down_pipelines = list(filter(is_pl_down, same_events))
-        if len(down_pipelines) == 1:
+        same_arn_events = list(filter(is_same_arn, events))
+        all_down_pipelines = list(filter(is_pl_down, same_arn_events))
+        same_down_pipelines = list(filter(is_same_pl, all_down_pipelines))
+        diff_down_pipelines = list(filter(is_diff_pl, all_down_pipelines))
+        if len(diff_down_pipelines) > 0 and len(same_down_pipelines) == 0:
             event["detail"]["degraded"] = bool(True)
             group["degraded"].append(event)
-        elif len(down_pipelines) > 1:
+        elif len(diff_down_pipelines) == 0 and len(same_down_pipelines) > 0:
+            event["detail"]["degraded"] = bool(True)
+            group["degraded"].append(event)
+        elif len(diff_down_pipelines) > 0 and len(same_down_pipelines) > 0:
             event["detail"]["degraded"] = bool(False)
             group["down"].append(event)
         else:


### PR DESCRIPTION
*Description of changes:*
Upon fetching `set` events from the client, the REST API runs thru degraded state verification on each event before returning them. 
- The bug here was that we were not taking the `pipeline #` into account when verifying the degraded state.
- The API is now verifying degraded state as before, including taking into account the different `pipelines`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
