### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/api/msam/chalicelib/connections.py
+++ b/api/msam/chalicelib/connections.py
@@ -11,7 +11,7 @@ import time
 from urllib.parse import urlparse
 
 from botocore.exceptions import ClientError
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from jsonpath_ng import parse
 
 from chalicelib import cache

--- a/api/msam/requirements.txt
+++ b/api/msam/requirements.txt
@@ -2,6 +2,6 @@ boto3
 botocore
 chalice
 jsonpath_ng
-fuzzywuzzy
+rapidfuzz
 stringcase
 requests


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
