### PR TITLE
Pipeline alert overlay now shows count for single pipelines

### DIFF
--- a/html/js/app/events.js
+++ b/html/js/app/events.js
@@ -1,175 +1,88 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-define(["app/server", "app/connections", "app/settings"],
-    function(server, connections, settings) {
+define(['app/server', 'app/connections', 'app/settings'], function(server, connections, settings) {
+    const listeners = [];
+    const settings_key = 'app-event-update-interval';
+    // cache events in 'set' state
+    // several modules use this at the same time
+    let current_set_events = [];
+    let previous_set_events = [];
+    // interval in millis to update the cache
+    let intervalID;
+    let update_interval;
 
-        var listeners = [];
+    const retrieve_for_state = function(state) {
+        var current_connection = connections.get_current();
+        var url = current_connection[0];
+        var api_key = current_connection[1];
+        var current_endpoint = `${url}/cloudwatch/events/state/${state}/groups`;
 
-        // cache events in 'set' state
-        // several modules use this at the same time
-
-        var current_set_events = []; // superset of all alert events
-        var previous_set_events = [];
-        var current_mediaconnect_events = [];
-        var previous_mediaconnect_events = [];
-        var current_medialive_events = [];
-        var previous_medialive_events = [];
-
-        // interval in millis to update the cache
-
-        var update_interval;
-
-        var intervalID;
-
-        var settings_key = "app-event-update-interval";
-
-        // or does this have to be union of eml and emx sets??
-        var retrieve_for_state = function(state) {
-            var current_connection = connections.get_current();
-            var url = current_connection[0];
-            var api_key = current_connection[1];
-            var current_endpoint = `${url}/cloudwatch/events/state/${state}`;
-
-            return new Promise(function(resolve, reject) {
-                server.get(current_endpoint, api_key)
-                    .then(resolve)
-                    .catch(function(error) {
-                        console.log(error);
-                        reject(error);
-                    });
-            });
-        };
-
-        var retrieve_for_state_source = function(state, source) {
-            var current_connection = connections.get_current();
-            var url = current_connection[0];
-            var api_key = current_connection[1];
-            if (source == "aws.medialive"){
-                var current_endpoint = `${url}/cloudwatch/events/state/${state}/groups`;
-            }
-            else {
-                var current_endpoint = `${url}/cloudwatch/events/state/${state}/${source}`;
-            }
-            return new Promise(function(resolve, reject) {
-                server.get(current_endpoint, api_key)
-                    .then(resolve)
-                    .catch(function(error) {
-                        console.log(error);
-                        reject(error);
-                    });
-            });
-        };
-
-        var cache_update = function() {
-            retrieve_for_state("set").then(function(res) {
-                // console.log("updated set event cache");
-                console.log('retrieve for all set state');
-                console.log(res);
-                previous_set_events = current_set_events;
-                current_set_events = res;
-                var added = _.differenceBy(current_set_events, previous_set_events, "alarm_id");
-                var removed = _.differenceBy(previous_set_events, current_set_events, "alarm_id");
-                if (added.length || removed.length) {
-                    for (let f of listeners) {
-                        f(current_set_events, previous_set_events);
-                    }
-                }
-            }).catch(function(error) {
-                console.log(error);
-            });
-
-            // for all medialive in set state, this includes multiplex
-            retrieve_for_state_source("set", "aws.medialive").then(function(res) {
-                previous_medialive_events = current_medialive_events;
-                current_medialive_events = res.degraded.concat(res.down).concat(res.running);
-                console.log("retrieve_for_state_source medialive");
-                console.log(res);
-                var added = _.differenceBy(current_medialive_events, previous_medialive_events, "alarm_id");
-                var removed = _.differenceBy(previous_medialive_events, current_medialive_events, "alarm_id");
-                if (added.length || removed.length) {
-                    for (let f of listeners) {
-                        f(current_medialive_events, previous_medialive_events);
-                    }
-                }
-            }).catch(function(error) {
-                console.log(error);
-            });
-
-            retrieve_for_state_source("set", "aws.mediaconnect").then(function(res) {
-                previous_mediaconnect_events = current_mediaconnect_events;
-                current_mediaconnect_events = res;
-                console.log("retrieve_for_state_source mediaconnect");
-                console.log(res);
-                var added = _.differenceBy(current_mediaconnect_events, previous_mediaconnect_events, "alarm_id");
-                var removed = _.differenceBy(previous_mediaconnect_events, current_mediaconnect_events, "alarm_id");
-                if (added.length || removed.length) {
-                    for (let f of listeners) {
-                        f(current_mediaconnect_events, previous_mediaconnect_events);
-                    }
-                }
-            }).catch(function(error) {
-                console.log(error);
-            });
-        };
-
-        var load_update_interval = function() {
-            return new Promise(function(resolve, reject) {
-                settings.get(settings_key).then(function(value) {
-                    seconds = Number.parseInt(value);
-                    update_interval = seconds * 1000;
-                    resolve();
+        return new Promise(function(resolve, reject) {
+            server.get(current_endpoint, api_key)
+                .then(resolve)
+                .catch(function(error) {
+                    console.log(error);
+                    reject(error);
                 });
+        });
+    };
+
+    const cache_update = function() {
+        retrieve_for_state('set').then(function(res) {
+            // console.log('updated set event cache');
+            // console.log(res);
+            previous_set_events = current_set_events;
+            current_set_events = res.degraded.concat(res.down).concat(res.running);
+
+            const added = _.differenceBy(current_set_events, previous_set_events, 'alarm_id');
+            const removed = _.differenceBy(previous_set_events, current_set_events, 'alarm_id');
+            
+            if (added.length || removed.length) {
+                for (let f of listeners) {
+                    f(current_set_events, previous_set_events);
+                }
+            }
+        }).catch(function(error) {
+            console.log(error);
+        });
+    };
+
+    const load_update_interval = function() {
+        return new Promise(function(resolve, reject) {
+            settings.get(settings_key).then(function(value) {
+                seconds = Number.parseInt(value);
+                update_interval = seconds * 1000;
+                resolve();
             });
-        };
+        });
+    };
 
-        var set_update_interval = function(seconds) {
-            // create a default
-            update_interval = seconds * 1000;
-            return settings.put(settings_key, seconds);
-        };
+    const set_update_interval = function(seconds) {
+        // create a default
+        update_interval = seconds * 1000;
+        return settings.put(settings_key, seconds);
+    };
 
-        var schedule_interval = function() {
-            if (intervalID) {
-                clearInterval(intervalID);
-            }
-            intervalID = setInterval(cache_update, update_interval);
-            console.log("events: interval scheduled " + update_interval + "ms");
-        };
+    const schedule_interval = function() {
+        if (intervalID) clearInterval(intervalID);
+        intervalID = setInterval(cache_update, update_interval);
+        console.log(`events: interval scheduled ${update_interval} ms`);
+    };
 
-        // load_update_interval().then(function() {
-        //     schedule_interval();
-        // });
+    load_update_interval();
 
-        load_update_interval();
-
-        return {
-            "get_cached_events": function() {
-                return {
-                    "current": current_set_events,
-                    "previous": previous_set_events,
-                    "current_mediaconnect": current_mediaconnect_events,
-                    "previous_mediaconnect": previous_mediaconnect_events,
-                    "current_medialive": current_medialive_events,
-                    "previous_medialive": previous_medialive_events
-                };
-            },
-            "add_callback": function(f) {
-                if (!listeners.includes(f)) {
-                    listeners.push(f);
-                }
-                if (!intervalID) {
-                    schedule_interval();
-                }
-            },
-            "set_update_interval": function(seconds) {
-                set_update_interval(seconds).then(function() {
-                    schedule_interval();
-                });
-            },
-            "get_update_interval": function() {
-                return update_interval;
-            }
-        };
-
-    });
+    return {
+        get_update_interval: () => update_interval,
+        get_cached_events: () => ({ current: current_set_events, previous: previous_set_events }),
+        add_callback: function(f) {
+            if (!listeners.includes(f)) listeners.push(f);
+            if (!intervalID) schedule_interval();
+        },
+        set_update_interval: function(seconds) {
+            set_update_interval(seconds).then(function() {
+                schedule_interval();
+            });
+        },
+    };
+});

--- a/html/js/app/mappers/nodes/medialive.js
+++ b/html/js/app/mappers/nodes/medialive.js
@@ -4,13 +4,13 @@
 define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "app/ui/svg_node"],
     function($, server, connections, region_promise, model, svg_node) {
 
-        const node_map_handler = (node_type, name, rgb, id, selected = true) => {
+        const node_map_handler = (node_type, name, rgb, id, selected, data) => {
             const local_id = id;
             const local_rgb = rgb;
             const local_name = name;
             const local_node_type = node_type;
             const method = selected ? 'selected' : 'unselected';
-            return () => svg_node[method](local_node_type, local_name, local_rgb, local_id);
+            return () => svg_node[method](local_node_type, local_name, local_rgb, local_id, data);
         };
 
         var update_channels = function(regionName) {
@@ -66,6 +66,9 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
 
         var map_channel = function(cache_entry) {
             var channel = JSON.parse(cache_entry.data);
+
+            // console.log('Channel: %o', channel);
+
             var name = channel.Name;
             var id = channel.Arn;
             var nodes = model.nodes;
@@ -87,12 +90,12 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                 name: name,
                 size: 55,
                 render: {
-                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false))(),
-                    normal_selected: (() => node_map_handler(node_type, name, rgb, id))(),
-                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false))(),
-                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id))(),
-                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false))(),
-                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id))(),
+                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false, channel))(),
+                    normal_selected: (() => node_map_handler(node_type, name, rgb, id, true, channel))(),
+                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false, channel))(),
+                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id, true, channel))(),
+                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false, channel))(),
+                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id, true, channel))(),
                 },
                 console_link: (function() {
                     var id = channel.Id;
@@ -118,6 +121,9 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
 
         var map_input = function(cache_entry) {
             var input = JSON.parse(cache_entry.data);
+
+            // console.log('Input: %o', input);
+
             var name = input.Name;
             var id = input.Arn;
             var nodes = model.nodes;
@@ -139,12 +145,12 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                 name: name,
                 size: 55,
                 render: {
-                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false))(),
-                    normal_selected: (() => node_map_handler(node_type, name, rgb, id))(),
-                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false))(),
-                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id))(),
-                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false))(),
-                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id))(),
+                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false, input))(),
+                    normal_selected: (() => node_map_handler(node_type, name, rgb, id, true, input))(),
+                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false, input))(),
+                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id, true, input))(),
+                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false, input))(),
+                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id, true, input))(),
                 },
                 console_link: (function() {
                     var id = input.Id;
@@ -168,6 +174,9 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
 
         var map_multiplex = function(cache_entry) {
             var input = JSON.parse(cache_entry.data);
+
+            // console.log('Input: %o', input);
+            
             var name = input.Name;
             var id = input.Arn;
             var nodes = model.nodes;
@@ -189,12 +198,12 @@ define(["jquery", "app/server", "app/connections", "app/regions", "app/model", "
                 name: name,
                 size: 55,
                 render: {
-                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false))(),
-                    normal_selected: (() => node_map_handler(node_type, name, rgb, id))(),
-                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false))(),
-                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id))(),
-                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false))(),
-                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id))(),
+                    normal_unselected: (() => node_map_handler(node_type, name, rgb, id, false, input))(),
+                    normal_selected: (() => node_map_handler(node_type, name, rgb, id, true, input))(),
+                    alert_unselected: (() => node_map_handler(node_type, name, "#ff0000", id, false, input))(),
+                    alert_selected: (() => node_map_handler(node_type, name, "#ff0000", id, true, input))(),
+                    degraded_unselected: (() => node_map_handler(node_type, name, degraded_rgb, id, false, input))(),
+                    degraded_selected: (() => node_map_handler(node_type, name, degraded_rgb, id, true, input))(),
                 },
                 console_link: (function() {
                     var id = input.Id;

--- a/html/js/app/ui/overlays/alarms_only.js
+++ b/html/js/app/ui/overlays/alarms_only.js
@@ -14,17 +14,12 @@ define(["jquery", "lodash", "app/alarms", "app/ui/overlays/overlay_tools"],
                     alarm_count += item.AlarmCount;
                 }
             }
-            tools.set_alarm_text("Active alarms: " + alarm_count, drawing, font_size, width);
+            tools.set_alarm_text(alarm_count, drawing, font_size, width);
         };
 
         var decorate = function(drawing, font_size, width, height, id) {
             decorate_alarms(drawing, font_size, width, height, id);
         };
 
-        return {
-            "match_type": match_type,
-            "decorate": decorate,
-            "informational": false
-        };
-
+        return { match_type, decorate, informational: false };
     });

--- a/html/js/app/ui/overlays/mediaconnect_flow.js
+++ b/html/js/app/ui/overlays/mediaconnect_flow.js
@@ -13,7 +13,7 @@ define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay
                     alarm_count += item.AlarmCount;
                 }
             }
-            tools.set_alarm_text("Active alarms: " + alarm_count, drawing, font_size, width);
+            tools.set_alarm_text(alarm_count, drawing, font_size, width);
         };
 
         var decorate_information = function(drawing, font_size, width, height, id) {
@@ -23,7 +23,7 @@ define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay
                 if (node.data.Source.EntitlementArn) {
                     source_type = "Entitlement";
                 }
-                tools.set_info_text("Type: " + source_type, drawing, font_size, width);
+                tools.set_info_text(source_type, drawing, font_size, width);
             }
         };
 
@@ -43,10 +43,5 @@ define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay
             decorate_information(drawing, font_size, width, height, id);
         };
 
-        return {
-            "match_type": match_type,
-            "decorate": decorate,
-            "informational": true
-        };
-
+        return { match_type, decorate, informational: true };
     });

--- a/html/js/app/ui/overlays/medialive_channel.js
+++ b/html/js/app/ui/overlays/medialive_channel.js
@@ -1,40 +1,41 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay_tools", "app/model"],
-    function($, _, alert_events, alarms, tools, model) {
+define(['jquery', 'lodash', 'app/events', 'app/alarms', 'app/ui/overlays/overlay_tools'],
+    function($, _, alert_events, alarms, tools) {
+        const match_type = 'MediaLive Channel';
 
-        var match_type = "MediaLive Channel";
+        const decorate_alarms = function(drawing, font_size, width, height, id) {
+            let alarm_count = 0;
+            const cached_alarms = alarms.get_subscribers_with_alarms();
 
-        var decorate_alarms = function(drawing, font_size, width, height, id) {
-            var alarm_count = 0;
-            for (let item of alarms.get_subscribers_with_alarms().current) {
+            for (let item of cached_alarms.current) {
                 if (item.ResourceArn == id) {
                     alarm_count += item.AlarmCount;
                 }
             }
-            tools.set_alarm_text("Active alarms: " + alarm_count, drawing, font_size, width);
+            tools.set_alarm_text(alarm_count, drawing, font_size, width);
         };
 
-        var decorate_events = function(drawing, font_size, width, height, id) {
-            var pipeline_alerts = [0, 0];
-            for (let item of alert_events.get_cached_events().current_medialive) {
+        const decorate_events = function(drawing, font_size, width, height, id, data) {
+            const isSinglePipeline = tools.has_single_pipeline(id, data);
+            let pipeline_alerts = isSinglePipeline ? 0 : [0, 0];
+            const cached_events = alert_events.get_cached_events();
+
+            for (let item of cached_events.current) {
                 if (item.resource_arn == id) {
-                    pipeline_alerts[parseInt(item.detail.pipeline)] += 1;
+                    if (isSinglePipeline) pipeline_alerts += 1;
+                    else pipeline_alerts[parseInt(item.detail.pipeline)] += 1;
                 }
             }
-            tools.set_event_text("Pipeline alerts: " + JSON.stringify(pipeline_alerts), drawing, font_size, width);
+            
+            tools.set_event_text(pipeline_alerts, drawing, font_size, width);
         };
 
-        var decorate = function(drawing, font_size, width, height, id) {
-            decorate_alarms(drawing, font_size, width, height, id);
-            decorate_events(drawing, font_size, width, height, id);
+        const decorate = function(drawing, font_size, width, height, id, data) {
+            decorate_alarms(drawing, font_size, width, height, id, data);
+            decorate_events(drawing, font_size, width, height, id, data);
         };
 
-        return {
-            "match_type": match_type,
-            "decorate": decorate,
-            "informational": true
-        };
-
+        return { match_type, decorate, informational: true };
     });

--- a/html/js/app/ui/overlays/medialive_multiplex.js
+++ b/html/js/app/ui/overlays/medialive_multiplex.js
@@ -1,40 +1,39 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-       define(["jquery", "lodash", "app/events", "app/alarms", "app/ui/overlays/overlay_tools", "app/model"],
-       function($, _, alert_events, alarms, tools, model) {
+define(['jquery', 'lodash', 'app/events', 'app/alarms', 'app/ui/overlays/overlay_tools'], 
+    function($, _, alert_events, alarms, tools) {
+        const match_type = 'MediaLive Multiplex';
 
-           var match_type = "MediaLive Multiplex";
+        const decorate_alarms = function(drawing, font_size, width, height, id) {
+            let alarm_count = 0;
+            for (let item of alarms.get_subscribers_with_alarms().current) {
+                if (item.ResourceArn == id) {
+                    alarm_count += item.AlarmCount;
+                }
+            }
+            tools.set_alarm_text(alarm_count, drawing, font_size, width);
+        };
 
-           var decorate_alarms = function(drawing, font_size, width, height, id) {
-               var alarm_count = 0;
-               for (let item of alarms.get_subscribers_with_alarms().current) {
-                   if (item.ResourceArn == id) {
-                       alarm_count += item.AlarmCount;
-                   }
-               }
-               tools.set_alarm_text("Active alarms: " + alarm_count, drawing, font_size, width);
-           };
+        const decorate_events = function(drawing, font_size, width, height, id, data) {
+            const isSinglePipeline = tools.has_single_pipeline(id, data);
+            let pipeline_alerts = isSinglePipeline ? 0 : [0, 0];
+            const cached_events = alert_events.get_cached_events();
 
-           var decorate_events = function(drawing, font_size, width, height, id) {
-               var pipeline_alerts = [0, 0];
-               for (let item of alert_events.get_cached_events().current_medialive) {
-                   if (item.resource_arn == id) {
-                       pipeline_alerts[parseInt(item.detail.pipeline)] += 1;
-                   }
-               }
-               tools.set_event_text("Pipeline alerts: " + JSON.stringify(pipeline_alerts), drawing, font_size, width);
-           };
+            for (let item of cached_events.current) {
+                if (item.resource_arn == id) {
+                    if (isSinglePipeline) pipeline_alerts += 1;
+                    else pipeline_alerts[parseInt(item.detail.pipeline)] += 1;
+                }
+            }
 
-           var decorate = function(drawing, font_size, width, height, id) {
-               decorate_alarms(drawing, font_size, width, height, id);
-               decorate_events(drawing, font_size, width, height, id);
-           };
+            tools.set_event_text(pipeline_alerts, drawing, font_size, width);
+        };
 
-           return {
-               "match_type": match_type,
-               "decorate": decorate,
-               "informational": true
-           };
+        const decorate = function(drawing, font_size, width, height, id, data) {
+            decorate_alarms(drawing, font_size, width, height, id, data);
+            decorate_events(drawing, font_size, width, height, id, data);
+        };
 
-       });
+        return { match_type, decorate, informational: true };
+    });

--- a/html/js/app/ui/overlays/overlay_tools.js
+++ b/html/js/app/ui/overlays/overlay_tools.js
@@ -1,40 +1,66 @@
 /*! Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
        SPDX-License-Identifier: Apache-2.0 */
 
-define(["jquery", "lodash", "app/alarms"], function($, _, alarms) {
+define(['jquery', 'lodash', 'app/events', 'app/alarms'], function($, _, alert_events, alarms) {
+    const info_y = 80;
+    const event_y = 125;
+    const alarm_y = 154;
+    const generateText = (type, data) => `${type}: ${JSON.stringify(data)}`;
 
-    var info_y = 80;
-    var event_y = 125;
-    var alarm_y = 154;
+    const fetch_running_pipelines_count = data => {
+        let pipelines_count = 0;
 
-    var draw_font_set_position = function(typeLabel, font_size, width) {
-        typeLabel.font({
-            family: 'Arial',
-            size: font_size
-        });
-        typeLabel.cx(width / 2);
+        if (_.has(data, 'ChannelClass')) {
+            if (data.ChannelClass === 'STANDARD') pipelines_count = 2;
+            else pipelines_count = 1;
+        } else if (_.has(data, 'Destinations')) pipelines_count = data.Destinations.length;
 
-    }
-
-    var set_alarm_text = function(text, drawing, font_size, width) {
-        var typeLabel = drawing.text(text).y(alarm_y);
-        draw_font_set_position(typeLabel, font_size, width);
-    }
-
-    var set_event_text = function(text, drawing, font_size, width) {
-        var typeLabel = drawing.text(text).y(event_y);
-        draw_font_set_position(typeLabel, font_size, width);
-    }
-
-    var set_info_text = function(text, drawing, font_size, width) {
-        var typeLabel = drawing.text(text).y(info_y);
-        draw_font_set_position(typeLabel, font_size, width);
-    }
-
-    return {
-        "set_alarm_text": set_alarm_text,
-        "set_event_text": set_event_text,
-        "set_info_text": set_info_text
+        return pipelines_count;
     };
 
+    const has_single_pipeline = (id, data) => {
+        const pipelines = {};
+        let pipelines_count = 0;
+
+        if (data) {
+            if (_.has(data, 'PipelinesRunningCount') && data.PipelinesRunningCount > 1) 
+                return false;
+            
+            pipelines_count = fetch_running_pipelines_count(data);
+
+            if (pipelines_count > 1)
+                return false;
+        }
+
+        const cached_events = alert_events.get_cached_events();
+
+        for (let item of cached_events.current) {
+            if (item.resource_arn == id) pipelines[parseInt(item.detail.pipeline)] += 1;
+            if (_.keys(pipelines).length > 1 && pipelines_count > 1) return false;
+        }
+
+        return true;
+    };
+
+    const draw_font_set_position = function(typeLabel, font_size, width) {
+        typeLabel.font({ family: 'Arial', size: font_size });
+        typeLabel.cx(width / 2);
+    };
+
+    const set_alarm_text = function(data, drawing, font_size, width) {
+        const typeLabel = drawing.text(generateText('Active alarms', data)).y(alarm_y);
+        draw_font_set_position(typeLabel, font_size, width);
+    };
+
+    const set_event_text = function(data, drawing, font_size, width) {
+        const typeLabel = drawing.text(generateText('Pipeline alerts', data)).y(event_y);
+        draw_font_set_position(typeLabel, font_size, width);
+    };
+
+    const set_info_text = function(data, drawing, font_size, width) {
+        const typeLabel = drawing.text(generateText('Type', data)).y(info_y);
+        draw_font_set_position(typeLabel, font_size, width);
+    };
+
+    return { set_alarm_text, set_event_text, set_info_text, has_single_pipeline };
 });

--- a/html/js/app/ui/svg_node.js
+++ b/html/js/app/ui/svg_node.js
@@ -4,6 +4,7 @@
 define(["jquery", "lodash", "app/window", "app/ui/util", "app/plugins"], function($, _, window, ui_util, plugins) {
 
     const max_line_length = 25;
+    const font_family = 'Arial';
     const work_div_id = ui_util.makeid();
     const work_div_style = 'overflow:hidden;top:-100%;left:-100%;position:absolute;opacity:0;';
     const work_div_html = `<div id="${work_div_id}" style="${work_div_style}"></div>`;
@@ -13,54 +14,54 @@ define(["jquery", "lodash", "app/window", "app/ui/util", "app/plugins"], functio
 
     const wordWrap = (str, max) => str.length > max ? [`${str.substring(0, max - 1)} [...]`] : [str];
 
-    const create = (type_name, node_name, node_rgb, selected, id) => {
-        const font_size = 25;
+    const create = (type_name, node_name, node_rgb, selected, id, data) => {
+        const inc_y = 35;
         const radius = 20;
         const width = 400;
         const height = 200;
-        const inc_y = 35;
+        const font_size = 25;
         const w_border = selected ? Math.ceil(width * 0.05) : Math.ceil(width * 0.025);
         let pos_y = 10;
 
         $("#" + work_div_id).empty();
+
         const drawing = SVG(work_div_id).size(width, height);
         drawing.rect(width, height).radius(radius).fill(selected ? selected_border_rgb : border_rgb);
         drawing.rect(width - w_border, height - w_border).radius(radius).fill(node_rgb).dmove(w_border / 2, w_border / 2);
+
         const typeLabel = drawing.text(type_name + ":").y(pos_y);
-        typeLabel.font({
-            family: 'Arial',
-            size: font_size,
-            weight: 'bold'
-        });
+        typeLabel.font({ family: font_family, size: font_size, weight: 'bold' });
         typeLabel.cx(width / 2);
+
         pos_y += inc_y;
+
         const lines = wordWrap(node_name, max_line_length);
+
         for (let value of lines) {
             const nameLabel = drawing.text(value).y(pos_y);
-            nameLabel.font({
-                family: 'Arial',
-                size: font_size
-            });
+            nameLabel.font({ family: font_family, size: font_size });
             nameLabel.cx(width / 2);
             pos_y += inc_y;
         }
 
         // give matching overlays a chance to supplement 'drawing'
-        const overlays = plugins.overlays;
         let found = false;
+        const overlays = plugins.overlays;
+
         for (let module of overlays) {
             let overlay = require(module);
             if (overlay.match_type == type_name) {
                 // console.log("applying overlay " + overlay.name);
-                overlay.decorate(drawing, font_size, width, height, id);
+                overlay.decorate(drawing, font_size, width, height, id, data);
                 found = true;
             }
         }
+
         // use the default overlay if needed
         if (!found) {
             // console.log("using default overlay for " + id)
             let overlay = require(plugins["default-overlay"]);
-            overlay.decorate(drawing, font_size, width, height, id);
+            overlay.decorate(drawing, font_size, width, height, id, data);
         }
 
         // export the SVG and turn it into an encoded inline image
@@ -76,10 +77,10 @@ define(["jquery", "lodash", "app/window", "app/ui/util", "app/plugins"], functio
     $("body").append(work_div_html);
 
     return {
-        selected: (type_name, node_name, node_rgb, id) => 
-            create(type_name, node_name, node_rgb, true, id),
-        unselected: (type_name, node_name, node_rgb, id) => 
-            create(type_name, node_name, node_rgb, false, id),
+        selected: (type_name, node_name, node_rgb, id, data) => 
+            create(type_name, node_name, node_rgb, true, id, data),
+        unselected: (type_name, node_name, node_rgb, id, data) => 
+            create(type_name, node_name, node_rgb, false, id, data),
         getDegradedRgb: () => degraded_rgb
     };
 });


### PR DESCRIPTION
*Issue #115*

*Description of changes:*

## Distribute the node data object

- We now pass the node data object further down the pipe so it reaches the overlays handlers.
- The overlay handlers now have access to the node data, providing the ability to determine if the node has a single pipeline.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
