### PR TITLE
Track of active flow with green lines 

### DIFF
--- a/html/js/app/connections.js
+++ b/html/js/app/connections.js
@@ -10,86 +10,85 @@ define(["jquery", "cookie", "app/window", "object_hash", "lodash"], function($, 
     var cookie_name_current = "MSAM_CURRENT",
         cookie_name_prefix = "MSAM_ENDPOINT_",
         session_current = "MSAM_CURRENT",
-        max_age = 7,
+        max_age = 7;
 
-        // return the stored connection objects
-        get_remembered = _.memoize(function() {
-            var history = [],
-                cookies = cookie.get();
-            for (let name of Object.keys(cookies)) {
-                if (name.startsWith(cookie_name_prefix)) {
-                    var payload = cookies[name],
-                        content = JSON.parse(window.atob(payload));
-                    history.push(content);
-                }
+    // return the stored connection objects
+    var get_remembered = _.memoize(function() {
+        var history = [],
+            cookies = cookie.get();
+        for (let name of Object.keys(cookies)) {
+            if (name.startsWith(cookie_name_prefix)) {
+                var payload = cookies[name],
+                    content = JSON.parse(window.atob(payload));
+                history.push(content);
             }
-            return history;
-        }),
+        }
+        return history;
+    });
 
-        // return the session copy or the cookie copy, or null
-        get_current = _.memoize(function() {
-            var current = null;
-            var encoded = window.sessionStorage.getItem(session_current);
-            if (encoded) {
-                current = JSON.parse(window.atob(encoded));
-            }
-            // get the cookie and refresh the expiration
-            var payload = cookie.get(cookie_name_current);
+    // return the session copy or the cookie copy, or null
+    var get_current = _.memoize(function() {
+        var current = null;
+        var encoded = window.sessionStorage.getItem(session_current);
+        if (encoded) {
+            current = JSON.parse(window.atob(encoded));
+        }
+        // get the cookie and refresh the expiration
+        var payload = cookie.get(cookie_name_current);
+        if (payload) {
+            // set the cookie again for expiration
+            cookie.set(cookie_name_current, payload, {
+                expires: max_age
+            });
+            var name = payload;
+            payload = cookie.get(name);
+            // something?
             if (payload) {
                 // set the cookie again for expiration
-                cookie.set(cookie_name_current, payload, {
+                cookie.set(name, payload, {
                     expires: max_age
                 });
-                var name = payload;
-                payload = cookie.get(name);
-                // something?
-                if (payload) {
-                    // set the cookie again for expiration
-                    cookie.set(name, payload, {
-                        expires: max_age
-                    });
-                    // set the session storage if not already
-                    if (!current) {
-                        window.sessionStorage.setItem(session_current, payload);
-                        current = JSON.parse(window.atob(payload));
-                    }
+                // set the session storage if not already
+                if (!current) {
+                    window.sessionStorage.setItem(session_current, payload);
+                    current = JSON.parse(window.atob(payload));
                 }
             }
-            return current;
-        }),
+        }
+        return current;
+    });
 
-        // update the history with another connection
-        set_current = function(url, api_key, store = true) {
-            clear_function_cache();
-            var current = [url, api_key];
-            window.sessionStorage.setItem(session_current, window.btoa(JSON.stringify(current)));
-            var cookie_name = cookie_name_prefix + hash.sha1(url);
-            var encoded = window.btoa(JSON.stringify(current));
-            if (store) {
-                // add or update MSAM_ENDPOINT_<ID> cookie
-                cookie.set(cookie_name, encoded, {
-                    expires: max_age
-                });
-                // rewrite MSAM_CURRENT cookie
-                cookie.set(cookie_name_current, cookie_name, {
-                    expires: max_age
-                });
-            } else {
-                cookie.remove(cookie_name_current);
-                cookie.remove(cookie_name);
-            }
-        },
+    // update the history with another connection
+    var set_current = function(url, api_key, store = true) {
+        clear_function_cache();
+        var current = [url, api_key];
+        window.sessionStorage.setItem(session_current, window.btoa(JSON.stringify(current)));
+        var cookie_name = cookie_name_prefix + hash.sha1(url);
+        var encoded = window.btoa(JSON.stringify(current));
+        if (store) {
+            // add or update MSAM_ENDPOINT_<ID> cookie
+            cookie.set(cookie_name, encoded, {
+                expires: max_age
+            });
+            // rewrite MSAM_CURRENT cookie
+            cookie.set(cookie_name_current, cookie_name, {
+                expires: max_age
+            });
+        } else {
+            cookie.remove(cookie_name_current);
+            cookie.remove(cookie_name);
+        }
+    };
 
-        clear_function_cache = function() {
-            get_current.cache.clear();
-            get_remembered.cache.clear();
-        },
+    var clear_function_cache = function() {
+        get_current.cache.clear();
+        get_remembered.cache.clear();
+    };
 
-
-        // is there a connection override on the URL parameters?
-        current_url = new URL(window.location),
-        endpoint = current_url.searchParams.get("endpoint"),
-        key = current_url.searchParams.get("key");
+    // is there a connection override on the URL parameters?
+    var current_url = new URL(window.location);
+    var endpoint = current_url.searchParams.get("endpoint");
+    var key = current_url.searchParams.get("key");
 
     if (endpoint && key) {
         // strip any trailing slashes
@@ -99,11 +98,7 @@ define(["jquery", "cookie", "app/window", "object_hash", "lodash"], function($, 
         }
         console.log("Connection override with URL parameters");
         set_current(endpoint, key, false);
-    };
+    }
 
-    return {
-        "get_remembered": get_remembered,
-        "set_current": set_current,
-        "get_current": get_current
-    };
+    return { get_remembered, set_current, get_current };
 });

--- a/html/js/app/mappers/connections/mediaconnect_flow_mediaconnect_flow.js
+++ b/html/js/app/mappers/connections/mediaconnect_flow_mediaconnect_flow.js
@@ -22,7 +22,8 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                             "arrows": "to",
                             "color": {
                                 "color": "black"
-                            }
+                            },
+                            dashes: false,
                         });
                     }
                     resolve();

--- a/html/js/app/mappers/connections/mediaconnect_flow_medialive_input.js
+++ b/html/js/app/mappers/connections/mediaconnect_flow_medialive_input.js
@@ -22,7 +22,8 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                             "arrows": "to",
                             "color": {
                                 "color": "black"
-                            }
+                            },
+                            dashes: false,
                         });
                     }
                     resolve();

--- a/html/js/app/mappers/connections/medialive_channel_mediapackage_channel.js
+++ b/html/js/app/mappers/connections/medialive_channel_mediapackage_channel.js
@@ -21,6 +21,7 @@ define(["jquery", "lodash", "app/model", "app/server", "app/connections"],
                             label: 'HLS',
                             arrows: "to",
                             color: { color: "black" },
+                            dashes: false,
                         };
                         const hasMoreConnections = _.filter(connections, function(o) {
                             if (o.from === connection.from && o.to === connection.to) {

--- a/html/js/app/mappers/connections/medialive_channel_mediastore_container.js
+++ b/html/js/app/mappers/connections/medialive_channel_mediastore_container.js
@@ -21,7 +21,8 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                             "arrows": "to",
                             "color": {
                                 "color": "black"
-                            }
+                            },
+                            dashes: false,
                         });
                     }
                     resolve();

--- a/html/js/app/mappers/connections/medialive_channel_multiplex.js
+++ b/html/js/app/mappers/connections/medialive_channel_multiplex.js
@@ -23,6 +23,7 @@ define(["jquery", "app/model", "app/server", "app/connections"],
                                 label: data.program,
                                 arrows: 'to',
                                 color: { color: 'black' },
+                                dashes: false,
                             };
                             const shouldEndWith = connection.arn.endsWith('0') ? '1' : '0';
                             const hasMoreConnections = _.filter(connections, function(o) {

--- a/html/js/app/model.js
+++ b/html/js/app/model.js
@@ -48,25 +48,16 @@ define(["jquery", "vis", "app/plugins", "app/server", "app/connections"], functi
         return new Promise(function(resolve, reject) {
             server.get(url + "/cached/arn/" + arn, api_key).then(function(cached) {
                 // we should get 0 or 1 results only
-                if (cached && cached.length == 1) {
-                    var cache_entry = cached[0];
-                    var data = JSON.parse(cache_entry.data);
-                    // node or connection?
-                    var node;
-                    if (data.to && data.from) {
-                        node = edges.get(arn);
-                    } else {
-                        node = nodes.get(arn);
-                    }
-                    if (!node) {
-                        reject("arn " + arn + " not found");
-                    } else {
-                        node.data = data;
-                        resolve(node);
-                    }
-                } else {
-                    reject("arn " + arn + " not found");
-                }
+                if (!cached || !cached.length) return reject(`arn ${arn} not found`);
+
+                var cache_entry = cached[0];
+                var data = JSON.parse(cache_entry.data);
+                // node or connection?
+                var node = data.to && data.from ? edges.get(arn) : nodes.get(arn);
+                if (!node) return reject(`arn ${arn} not found`);
+
+                node.data = data;
+                resolve(node);
             }).catch(function(error) {
                 console.log(error);
                 reject(error);
@@ -112,13 +103,5 @@ define(["jquery", "vis", "app/plugins", "app/server", "app/connections"], functi
     // clear the model at module definition
     reset();
 
-    return {
-        "nodes": nodes,
-        "edges": edges,
-        "reset": reset,
-        "map": map,
-        "update": update,
-        "put_records": put_records,
-        "delete_record": delete_record
-    }
+    return { nodes, edges, reset, map, update, put_records, delete_record }
 });

--- a/html/js/app/ui/event_alert_indicators.js
+++ b/html/js/app/ui/event_alert_indicators.js
@@ -102,6 +102,7 @@ define(["jquery", "lodash", "app/model", "app/events", "app/ui/diagrams"],
             const newEdgeOpts = {
                 color: { color: newState !== 'normal' ? 'red' : 'black' },
                 dashes: newState !== 'normal',
+                hoverWidth: 1
             };
             const edges = !_.has(alertDetails, 'pipeline') ? getEdges(node.id) 
                 : getEdgesByPipeline(node.id, parseInt(alertDetails.pipeline || 0));
@@ -111,6 +112,7 @@ define(["jquery", "lodash", "app/model", "app/events", "app/ui/diagrams"],
                 if (edge.color.color !== newEdgeOpts.color.color || edge.dashes !== newEdgeOpts.dashes) {
                     edge.color = newEdgeOpts.color;
                     edge.dashes = newEdgeOpts.dashes;
+                    edge.hoverWidth = newEdgeOpts.hoverWidth;
                     model.edges.update(edge);
                     updateUIHandler(edge, alertState, 'edges');
 
@@ -125,11 +127,12 @@ define(["jquery", "lodash", "app/model", "app/events", "app/ui/diagrams"],
                     const otherEdges = getEdges(node.id, true)
                         .filter(e => e.data.pipeline === edge.data.pipeline);
                     console.log('Other Edges => %o', otherEdges);
-                    
+
                     otherEdges.forEach(oedge => {
                         if (oedge.color.color !== newEdgeOpts.color.color || oedge.dashes !== newEdgeOpts.dashes) {
                             oedge.color = newEdgeOpts.color;
                             oedge.dashes = newEdgeOpts.dashes;
+                            oedge.hoverWidth = newEdgeOpts.hoverWidth;
                             model.edges.update(oedge);
                             updateUIHandler(oedge, alertState, 'edges');
                         }


### PR DESCRIPTION
*Issue #84*

*Description of changes:*

## Display each pipeline's state

- Edges do return to their normal state as test

Degraded Node (One Pipeline Down):
![Screenshot 2020-06-25 18 54 53](https://user-images.githubusercontent.com/7432155/85806676-65e62800-b715-11ea-9501-4900046ad088.png)

Alerting Node (Multiple Pipelines Down):
![Screenshot 2020-06-25 18 56 11](https://user-images.githubusercontent.com/7432155/85806745-96c65d00-b715-11ea-8a4e-e5a3accb65cc.png)

## Aggregated logic to event/alert handling

- Because we already know the state of the pipeline when we get alerted, we are able to leverage that data and update the edges along with the node itself.
- Although, the node only updates if the resulting node is different than the current - we always update the edges on all alerts. 

## Styling Edges

- There are way too many possible styles to demonstrate the down pipelines. Based on the [edges API](https://visjs.github.io/vis-network/docs/network/edges.html#) `Dashed with Bolded` is the best style I think.
- Because the edge width is minimal, increasing the width for broken pipelines seems a bit excessive of a change.

## Additional Screenshots

![Screen Shot 2020-06-25 at 4 05 49 PM](https://user-images.githubusercontent.com/7432155/85808874-bc566500-b71b-11ea-8034-49e5e81642d8.png)

### With font background highlighting:
![Screen Shot 2020-06-25 at 4 34 30 PM](https://user-images.githubusercontent.com/7432155/85808885-c4160980-b71b-11ea-9352-3aba6cdcb925.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
