### PR TITLE
Updating BrowserAppBucket content location

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ fi
 mkdir -p $HTMLWORK
 
 # add build stamp
-cp -R $ORIGIN/html/ $HTMLWORK
+cp -R $ORIGIN/html/* $HTMLWORK
 echo "updating browser app build stamp"
 sed -e "s/DEV_0_0_0/$STAMP/g" $ORIGIN/html/js/app/build.js >$HTMLWORK/js/app/build.js
 


### PR DESCRIPTION
- Modifying deploy.sh to have BrowserAppBucket contents sit in the root of the S3 bucket as opposed to under html/.
(Resolves an issue where CloudFront displays an Access Denied page due to being confused on the location of the DefaultRootObject defined in the msam-browser-app-release template.)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
